### PR TITLE
mix: use upstream exml to resolve :badxml error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ```elixir
 def deps do
   [{:romeo, "~> 0.4.0"},
-   {:exml, github: "esl/exml"}]
+   {:exml, github: "paulgray/exml"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Romeo.Mixfile do
 
   defp deps do
     [{:connection, "~> 1.0"},
-     {:exml, github: "esl/exml"},
+     {:exml, github: "paulgray/exml"},
 
      # Docs deps
      {:earmark, "~> 0.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -10,7 +10,7 @@
   "ex_doc": {:hex, :ex_doc, "0.10.0"},
   "excoveralls": {:hex, :excoveralls, "0.4.2"},
   "exjsx": {:hex, :exjsx, "3.2.0"},
-  "exml": {:git, "https://github.com/esl/exml.git", "d7b745fa89389b53706a07f33775f1f814c66cb4", []},
+  "exml": {:git, "https://github.com/paulgray/exml.git", "d04d0dfc956bd2bf5d9629a7524c6840eb02df28", []},
   "exrm": {:hex, :exrm, "0.19.9"},
   "getopt": {:hex, :getopt, "0.8.2"},
   "hackney": {:hex, :hackney, "1.4.4"},


### PR DESCRIPTION
Hey Sonny

XMPP is new to me, and I avoid XML like the plague, so this is a short PR with a long story. If you can see what's wrong with the XML maybe we can get this addressed in https://github.com/esl/exml directly. 
## issue

A new `hedwig_xmpp` or `hedwig_hipchat` app fails to connect to jabber or hipchat, due to failures in XML parsing early on. The upstream https://github.com/paulgray/exml dependency handles this correctly.
## error as seen from hedwig_xmpp

``` elixir

10:31:41.189 [error] GenServer #PID<0.219.0> terminating
** (stop) {:badxml, {:xmlel, "iq", [{"type", "set"}, {"id", "7a1c"}], {:xmlel, "bind", [{"xmlns", "urn:ietf:params:xml:ns:xmpp-bind"}], [{:xmlel, "resource", [], {:xmlcdata, ""}}]}}, {:function_clause, [{:lists, :map, [#Function<1.76711811/1 in :exml.item_to_iolist/1>, {:xmlel, "bind", [{"xmlns", "urn:ietf:params:xml:ns:xmpp-bind"}], [{:xmlel, "resource", [], {:xmlcdata, ""}}]}], [file: 'lists.erl', line: 1237]}, {:exml, :item_to_iolist, 1, [file: 'src/exml.erl', line: 96]}, {:exml, :to_binary, 1, [file: 'src/exml.erl', line: 80]}, {Romeo.Transports.TCP, :send, 2, [file: 'lib/romeo/transports/tcp.ex', line: 178]}, {Romeo.Transports.TCP, :bind, 1, [file: 'lib/romeo/transports/tcp.ex', line: 113]}, {Romeo.Transports.TCP, :start_protocol, 1, [file: 'lib/romeo/transports/tcp.ex', line: 55]}, {Romeo.Connection, :connect, 2, [file: 'lib/romeo/connection.ex', line: 84]}, {Connection, :enter_connect, 5, [file: 'lib/connection.ex', line: 623]}]}}
    (exml) src/exml.erl:81: :exml.to_binary/1
    (romeo) lib/romeo/transports/tcp.ex:178: Romeo.Transports.TCP.send/2
    (romeo) lib/romeo/transports/tcp.ex:113: Romeo.Transports.TCP.bind/1
    (romeo) lib/romeo/transports/tcp.ex:55: Romeo.Transports.TCP.start_protocol/1
    (romeo) lib/romeo/connection.ex:84: Romeo.Connection.connect/2
    (connection) lib/connection.ex:623: Connection.enter_connect/5
    (stdlib) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: nil
State: %Romeo.Connection{features: %Romeo.Connection.Features{amp?: false, compression?: false, mechanisms: [], registration?: false, stream_management?: false, tls?: false}, host: nil, jid: "...@chat.hipchat.com", nickname: "alfred", owner: #PID<0.218.0>, parser: nil, password: "...", port: nil, preferred_auth_mechanisms: [], require_tls: false, resource: "", rooms: [], socket: nil, socket_opts: [], ssl_opts: [], timeout: 5000, transport: Romeo.Transports.TCP}
```
## what was that stacktrace?

I assume you've got https://github.com/ferd/recon in your ERL_LIBS already.

``` elixir

$ iex --app recon -S mix

ieX()>  l(:exml)
ieX()>   :recon_trace.calls({:exml, :to_binary, :_} , 20, [{:pid, :all}, {:scope, :local}, :stack, :return])
1

ieX()>  {:ok, pid} = Romeo.Connection.start_link([jid: "...@..., password: "...", nickname: "..."])
...
```
## invalid XML returned from Jabber & Hipchat

Using recon as above, the following traces that trigger `:badxml` are obtained just before the GenServer bites the dust. 
### ejabberd server

paste into your erlang session:

``` erlang
exml:to_binary({xmlel,<<"iq">>,
       [{<<"type">>,<<"set">>},{<<"id">>,<<"8e5c">>}],
       {xmlel,<<"bind">>,
              [{<<"xmlns">>,<<"urn:ietf:params:xml:ns:xmpp-bind">>}],
              [{xmlel,<<"resource">>,[],{xmlcdata,<<>>}}]}}).
```

result:

``` erlang
** exception error: {badxml,{xmlel,<<"iq">>,
                                   [{<<"type">>,<<"set">>},{<<"id">>,<<"8e5c">>}],
                                   {xmlel,<<"bind">>,
                                          [{<<"xmlns">>,<<"urn:ietf:params:xml:ns:xmpp-bind">>}],
                                          [{xmlel,<<"resource">>,[],{xmlcdata,<<>>}}]}},
                            {function_clause,[{lists,map,
                                                     [#Fun<exml.1.76711811>,
                                                      {xmlel,<<"bind">>,
                                                             [{<<"xmlns">>,<<"urn:ietf:params:xml:ns:xmpp-bind">>}],
                                                             [{xmlel,<<"resource">>,[],{xmlcdata,<<>>}}]}],
                                                     [{file,"lists.erl"},{line,1237}]},
                                              {exml,item_to_iolist,1,[{file,"src/exml.erl"},{line,96}]},
                                              {exml,to_binary,1,[{file,"src/exml.erl"},{line,80}]},
                                              {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,674}]},
                                              {shell,exprs,7,[{file,"shell.erl"},{line,686}]},
                                              {shell,eval_exprs,7,[{file,"shell.erl"},{line,641}]},
                                              {shell,eval_loop,3,[{file,"shell.erl"},{line,626}]}]}}
     in function  exml:to_binary/1 (src/exml.erl, line 81)
```
### hipchat XMPP

paste into your erlang session:

``` erlang
exml:to_binary({xmlel,<<"iq">>, 
       [{<<"type">>,<<"set">>},{<<"id">>,<<"0356">>}],
       {xmlel,<<"bind">>,
              [{<<"xmlns">>,<<"urn:ietf:params:xml:ns:xmpp-bind">>}],
              [{xmlel,<<"resource">>,[],{xmlcdata,<<>>}}]}}).
```

result:

``` erlang
** exception error: {badxml,{xmlel,<<"iq">>,
                                   [{<<"type">>,<<"set">>},{<<"id">>,<<"0356">>}],
                                   {xmlel,<<"bind">>,
                                          [{<<"xmlns">>,<<"urn:ietf:params:xml:ns:xmpp-bind">>}],
                                          [{xmlel,<<"resource">>,[],{xmlcdata,<<>>}}]}},
                            {function_clause,[{lists,map,
                                                     [#Fun<exml.1.76711811>,
                                                      {xmlel,<<"bind">>,
                                                             [{<<"xmlns">>,<<"urn:ietf:params:xml:ns:xmpp-bind">>}],
                                                             [{xmlel,<<"resource">>,[],{xmlcdata,<<>>}}]}],
                                                     [{file,"lists.erl"},{line,1237}]},
                                              {exml,item_to_iolist,1,[{file,"src/exml.erl"},{line,96}]},
                                              {exml,to_binary,1,[{file,"src/exml.erl"},{line,80}]},
                                              {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,674}]},
                                              {shell,exprs,7,[{file,"shell.erl"},{line,686}]},
                                              {shell,eval_exprs,7,[{file,"shell.erl"},{line,641}]},
                                              {shell,eval_loop,3,[{file,"shell.erl"},{line,626}]}]}}
     in function  exml:to_binary/1 (src/exml.erl, line 81)
```

 BTW I was unable to run romeo's test suite to check if switching repos broke other stuff.

``` elixir
Compiled lib/romeo/transports/tcp.ex
Generated romeo app
Consolidated JSX.Encoder
Consolidated List.Chars
Consolidated String.Chars
Consolidated Collectable
Consolidated Enumerable
Consolidated IEx.Info
Consolidated Inspect
Starting ejabberd...

13:07:03.292 [error] E(#PID<0.7526.0>::ejabberd_config:223) : Cannot load /Volumes/ramdisk/romeo/config/ejabberd.yml: no such file or directory
Crash dump is being written to: /dev/null...[1]    17919 abort      mix test
```
