### PR TITLE
Change unknown message log from info to debug.

### DIFF
--- a/lib/romeo/connection.ex
+++ b/lib/romeo/connection.ex
@@ -122,7 +122,7 @@ defmodule Romeo.Connection do
       {:error, _} = error ->
         {:disconnect, error, conn}
       :unknown ->
-        Logger.info fn ->
+        Logger.debug fn ->
           [inspect(__MODULE__), ?\s, inspect(self), " received message: " | inspect(info)]
         end
         {:noreply, conn}


### PR DESCRIPTION
This PR changes the unknown message log from info to debug.

We recently started using this library to send GCM push notifications and it is 👌 but because GCM sends unexpected messages to Romeo our logs are filling up pretty quickly.
