### PR TITLE
Close connection

### DIFF
--- a/lib/romeo/connection.ex
+++ b/lib/romeo/connection.ex
@@ -122,7 +122,7 @@ defmodule Romeo.Connection do
       {:error, _} = error ->
         {:disconnect, error, conn}
       :unknown ->
-        Logger.info fn ->
+        Logger.debug fn ->
           [inspect(__MODULE__), ?\s, inspect(self), " received message: " | inspect(info)]
         end
         {:noreply, conn}

--- a/lib/romeo/connection.ex
+++ b/lib/romeo/connection.ex
@@ -89,6 +89,10 @@ defmodule Romeo.Connection do
     end
   end
 
+  def disconnect({:close, from}, %{socket: socket, transport: transport} = conn) do
+    transport.disconnect({:close, from}, socket)
+    {:stop, {:shutdown, :closed}, conn}
+  end
   def disconnect(info, %{socket: socket, transport: transport} = conn) do
     transport.disconnect(info, socket)
     {:connect, :reconnect, reset_connection(conn)}


### PR DESCRIPTION
This will change the `Connection.close()` method to actually close the connection and shutdown the process, as described in the docs.
