### PR TITLE
Handle multiple stanzas resulting from parse of binary xml.

### DIFF
--- a/lib/romeo/transports/tcp.ex
+++ b/lib/romeo/transports/tcp.ex
@@ -240,6 +240,9 @@ defmodule Romeo.Transports.TCP do
   def handle_message({:tcp, socket, data}, %{socket: {:gen_tcp, socket}} = conn) do
     {:ok, _, _} = handle_data(data, conn)
   end
+  def handle_message({:xmlstreamelement, stanza}, %{owner: owner} = conn) do
+    {:ok, conn, stanza}
+  end
   def handle_message({:tcp_closed, socket}, %{socket: {:gen_tcp, socket}}) do
     {:error, :closed}
   end


### PR DESCRIPTION
Hi. I'm using romeo to implement a bot in a jabber component. When I was writing code to handle service discovery, I noticed that when the chat client sent a bunch of service discovery iq stanzas in quick succession, many got dropped and were logged as :unknown by Romeo.Connection.handle_info().
