### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,18 @@ elixir:
   - 1.2.6
 otp_release:
   - 18.0
+env:
+  global:
+  - MIX_ENV=test
 sudo: false
-before_script:
+install:
+  - mix local.hex --force
   - mix local.rebar --force
+  - mix deps.get
+before_script:
+  - env TRAVIS=false mix compile
   - mix ejabberd.gen.config
+script:
+  - mix test
 after_script:
-  - MIX_ENV=test mix coveralls.travis
+  - mix coveralls.travis


### PR DESCRIPTION
During compile step, set TRAVIS=false

This avoids https://github.com/processone/p1_utils/blob/master/rebar.config.script#L66 which apparently is what was breaking the build
