### PR TITLE
Ignore whitespace keepalive messages

### DIFF
--- a/lib/romeo/transports/tcp.ex
+++ b/lib/romeo/transports/tcp.ex
@@ -200,6 +200,7 @@ defmodule Romeo.Transports.TCP do
     receive do
       {:xmlstreamelement, stanza} ->
         fun.(conn, stanza)
+      {:tcp, ^socket, " "} -> conn
       {:tcp, ^socket, data} ->
         :ok = activate({:gen_tcp, socket})
         {:ok, conn, stanza} = parse_data(conn, data)
@@ -217,6 +218,7 @@ defmodule Romeo.Transports.TCP do
     receive do
       {:xmlstreamelement, stanza} ->
         fun.(conn, stanza)
+      {:ssl, ^socket, " "} -> conn
       {:ssl, ^socket, data} ->
         :ok = activate({:ssl, socket})
         {:ok, conn, stanza} = parse_data(conn, data)

--- a/lib/romeo/transports/tcp.ex
+++ b/lib/romeo/transports/tcp.ex
@@ -161,7 +161,7 @@ defmodule Romeo.Transports.TCP do
     %{conn | parser: parser}
   end
 
-  defp parse_data(%Conn{jid: jid, owner: owner, parser: parser} = conn, data, send_to_owner \\ false) do
+  defp parse_data(%Conn{jid: jid, parser: parser} = conn, data) do
     Logger.debug fn -> "[#{jid}][INCOMING] #{inspect data}" end
 
     parser = :fxml_stream.parse(parser, data)
@@ -268,7 +268,7 @@ defmodule Romeo.Transports.TCP do
 
   defp handle_data(data, %{socket: socket} = conn) do
     :ok = activate(socket)
-    {:ok, _conn, _stanza} = parse_data(conn, data, false)
+    {:ok, _conn, _stanza} = parse_data(conn, data)
   end
 
   defp whitespace_only?(data), do: Regex.match?(~r/^\s+$/, data)


### PR DESCRIPTION
As per ~~https://xmpp.org/extensions/xep-0304.html~~ https://tools.ietf.org/html/rfc5626#section-4.4.

At some point we might actually want to check their frequency/period against the server-provided keep alive interval and use that information for connection status.  For now, we should not crash if we receive a whitespace message.

It's also worth noting that https://github.com/futureflynet/romeo/commit/41726c9924d44d8e04efa0222cae14acf990873d attempts to address the same problem, but that fix does not seem sufficient.
