### PR TITLE
add support for x-oauth2 auth mechanism

### DIFF
--- a/lib/romeo/auth.ex
+++ b/lib/romeo/auth.ex
@@ -58,6 +58,12 @@ defmodule Romeo.Auth do
     mod.send(conn, Romeo.Stanza.auth("PLAIN", Romeo.Stanza.base64_cdata(payload)))
   end
 
+  defp authenticate_with("X-OAUTH2", %{transport: mod, jid: jid, password: password} = conn) do
+    payload = <<0>> <> jid <> <<0>> <> password
+    additional_attrs = [{"auth:service", "oauth2"}, {"xmlns:auth", "http://www.google.com/talk/protocol/auth"}]
+    mod.send(conn, Romeo.Stanza.auth("X-OAUTH2", Romeo.Stanza.base64_cdata(payload), additional_attrs))
+  end
+
   defp authenticate_with("DIGEST-MD5", _conn) do
     raise "Not implemented"
   end

--- a/lib/romeo/stanza.ex
+++ b/lib/romeo/stanza.ex
@@ -103,13 +103,14 @@ defmodule Romeo.Stanza do
     cdata = xmlcdata(content: hash)
     xmlel(name: "handshake", children: [cdata])
   end
-  
+
   def auth(mechanism), do: auth(mechanism, [])
-  def auth(mechanism, body) do
+  def auth(mechanism, body, additional_attrs \\ []) do
     xmlel(name: "auth",
       attrs: [
         {"xmlns", ns_sasl},
         {"mechanism", mechanism}
+        | additional_attrs
       ],
       children: [body])
   end


### PR DESCRIPTION
as specified at https://developers.google.com/talk/jep_extensions/oauth

A mutually-exclusive auth mechanism extension api is forthcoming, if extensions don't belong in romeo
