### PR TITLE
Alternative auth mechanism extension api

### DIFF
--- a/lib/romeo/auth.ex
+++ b/lib/romeo/auth.ex
@@ -67,11 +67,11 @@ defmodule Romeo.Auth do
   end
 
   defp authenticate_with("DIGEST-MD5", _conn) do
-    raise "Not implemented"
+    raise "Not implemented, please provide an implementation such as preferred_auth_mechanisms: [{\"DIGEST-MD5\", fn conn -> conn end}]"
   end
 
   defp authenticate_with("SCRAM-SHA-1", _conn) do
-    raise "Not implemented"
+    raise "Not implemented, please provide an implementation such as preferred_auth_mechanisms: [{\"SCRAM-SHA-1\", fn conn -> conn end}]"
   end
 
   defp authenticate_with("ANONYMOUS", %{transport: mod} = conn) do
@@ -79,7 +79,7 @@ defmodule Romeo.Auth do
   end
 
   defp authenticate_with("EXTERNAL", _conn) do
-    raise "Not implemented"
+    raise "Not implemented, please provide an implementation such as preferred_auth_mechanisms: [{\"EXTERNAL\", fn conn -> conn end}]"
   end
 
   defp success?(%{transport: mod} = conn) do

--- a/lib/romeo/stanza.ex
+++ b/lib/romeo/stanza.ex
@@ -103,13 +103,14 @@ defmodule Romeo.Stanza do
     cdata = xmlcdata(content: hash)
     xmlel(name: "handshake", children: [cdata])
   end
-  
+
   def auth(mechanism), do: auth(mechanism, [])
-  def auth(mechanism, body) do
+  def auth(mechanism, body, additional_attrs \\ []) do
     xmlel(name: "auth",
       attrs: [
         {"xmlns", ns_sasl},
         {"mechanism", mechanism}
+        | additional_attrs
       ],
       children: [body])
   end


### PR DESCRIPTION
This PR allows library users to specify their own auth mechanism implementations in the `preferred_auth_mechanism` list. Because of the X in XMPP, it is likely preferable for romeo to avoid implementing extensions to the protocol, but instead provide extension apis.  The proposed API retains the orderedness of the `preferred_auth_mechanisms` list and still checks against the server's supported auth mechanisms.

Example usage:

``` elixir
  def start_link({host, jid, access_token}) do
    romeo_options =
      [host: host,
       jid: jid,
       password: access_token,
       preferred_auth_mechanisms: [{"X-OAUTH2", &oauth2_mechanism/1}]]

    {:ok, pid} = Romeo.Connection.start_link romeo_options
  end

  defp oauth2_mechanism(%{transport: mod, jid: jid, password: password} = conn) do
    payload = <<0>> <> jid <> <<0>> <> password
    additional_attrs = [{"auth:service", "oauth2"}, {"xmlns:auth", "http://www.google.com/talk/protocol/auth"}]
    mod.send(conn, Romeo.Stanza.auth("X-OAUTH2", Romeo.Stanza.base64_cdata(payload), additional_attrs))
  end
```
