### PR TITLE
Allow Romeo.Connection.start_link to pass through options to Connection.start_link

### DIFF
--- a/lib/romeo/connection.ex
+++ b/lib/romeo/connection.ex
@@ -50,14 +50,14 @@ defmodule Romeo.Connection do
 
   [0]: http://xmpp.org/extensions/xep-0114.html
   """
-  def start_link(opts) do
-    opts =
-      opts
+  def start_link(args, options \\ []) do
+    args =
+      args
       |> Keyword.put_new(:timeout, @timeout)
       |> Keyword.put_new(:transport, @default_transport)
       |> Keyword.put(:owner, self)
 
-    Connection.start_link(__MODULE__, struct(__MODULE__, opts))
+    Connection.start_link(__MODULE__, struct(__MODULE__, args), options)
   end
 
   @doc """


### PR DESCRIPTION
 Allow `Romeo.Connection.start_link` to pass through optional opts to `Connection.start_link`

As an example of usage, this names the Romeo process:

``` elixir
{:ok, pid} = Romeo.Connection.start_link romeo_options, name: :"Elixir.Romeo.Connection:#{something_unique}"
```

Function arguments are renamed according to the second and third arguments to `GenServer.start_link/3`.
