### PR TITLE
Added option to use legacy TLS connect method.

### DIFF
--- a/lib/romeo/connection.ex
+++ b/lib/romeo/connection.ex
@@ -7,6 +7,7 @@ defmodule Romeo.Connection do
   alias Romeo.Connection.Features
 
   defstruct component: false,
+            legacy_tls: false,
             features: %Features{},
             host: nil,
             jid: nil,

--- a/lib/romeo/transports/tcp.ex
+++ b/lib/romeo/transports/tcp.ex
@@ -19,17 +19,23 @@ defmodule Romeo.Transports.TCP do
   import Kernel, except: [send: 2]
 
   @spec connect(Keyword.t) :: {:ok, state} | {:error, any}
-  def connect(%Conn{host: host, port: port, socket_opts: socket_opts} = conn) do
+  def connect(%Conn{host: host, port: port, socket_opts: socket_opts, legacy_tls: legacy_tls} = conn) do
     host = (host || host(conn.jid)) |> to_char_list
     port = (port || @default_port)
-
+    
     conn = %{conn | host: host, port: port, socket_opts: socket_opts}
-
+    
     case :gen_tcp.connect(host, port, socket_opts ++ @socket_opts, conn.timeout) do
       {:ok, socket} ->
         Logger.info fn -> "Established connection to #{host}" end
         parser = :fxml_stream.new(self(), :infinity, [:no_gen_server])
-        start_protocol(%{conn | parser: parser, socket: {:gen_tcp, socket}})
+        conn = %{conn | parser: parser, socket: {:gen_tcp, socket}}
+        conn = if legacy_tls do
+          upgrade_to_tls(conn)
+        else
+          conn
+        end
+        start_protocol(conn)
       {:error, _} = error ->
         error
     end


### PR DESCRIPTION
Some services require one to use legacy TLS connect method where you connect to the server directly using TLS instead of negotiating the secure connection using STARTTLS. One example of such service is Google's [Firebase](http://firebase.google.com).

This pull request adds connection option `legacy_tls = true|false` that can be set to enable the use of legacy TLS connect method. It simply does `Romeo.Transports.TCP.upgrade_to_tls` on the connection before starting the protocol negotiation. 
