### PR TITLE
Fix anonymous login

### DIFF
--- a/lib/romeo/stanza.ex
+++ b/lib/romeo/stanza.ex
@@ -104,8 +104,27 @@ defmodule Romeo.Stanza do
     xmlel(name: "handshake", children: [cdata])
   end
 
-  def auth(mechanism), do: auth(mechanism, [])
-  def auth(mechanism, body, additional_attrs \\ []) do
+  def auth(mechanism), do: auth(mechanism, [], [])
+  def auth(mechanism, body) do
+    auth(mechanism, body, [])
+  end
+  def auth(mechanism, [], []) do
+    xmlel(name: "auth",
+      attrs: [
+        {"xmlns", ns_sasl},
+        {"mechanism", mechanism},
+      ],
+      children: [])
+  end
+  def auth(mechanism, body, []) do
+    xmlel(name: "auth",
+      attrs: [
+        {"xmlns", ns_sasl},
+        {"mechanism", mechanism},
+      ],
+      children: [body])
+  end
+  def auth(mechanism, body, additional_attrs) do
     xmlel(name: "auth",
       attrs: [
         {"xmlns", ns_sasl},

--- a/test/romeo/stanza_test.exs
+++ b/test/romeo/stanza_test.exs
@@ -61,6 +61,10 @@ defmodule Romeo.StanzaTest do
       "<auth xmlns='#{ns_sasl}' mechanism='PLAIN'>AHVzZXJuYW1lAHBhc3N3b3Jk</auth>"
   end
 
+  test "auth anonymous" do
+    assert Stanza.auth("ANONYMOUS") |> Stanza.to_xml == "<auth xmlns='#{ns_sasl}' mechanism='ANONYMOUS'/>"
+  end
+
   test "bind" do
     assert Stanza.bind("hedwig") |> Stanza.to_xml =~
       ~r"<iq type='set' id='(.*)'><bind xmlns='#{ns_bind}'><resource>hedwig</resource></bind></iq>"


### PR DESCRIPTION
 - Passing the the mechanism ANONYMOUS without body to the Stanza.auth method would result in an invalid :xmlel element, because the children element would be a list of a empty list, which would result in error when converting to xml string.