### PR TITLE
Ignore xmlstreamcdata whitespace (otp 22)

### DIFF
--- a/lib/romeo/transports/tcp.ex
+++ b/lib/romeo/transports/tcp.ex
@@ -200,6 +200,8 @@ defmodule Romeo.Transports.TCP do
   def recv({:ok, conn}, fun), do: recv(conn, fun)
   def recv(%Conn{socket: {:gen_tcp, socket}, timeout: timeout} = conn, fun) do
     receive do
+      {:xmlstreamcdata, " "} ->
+        recv(conn, fun)
       {:xmlstreamelement, stanza} ->
         fun.(conn, stanza)
       {:tcp, ^socket, data} ->
@@ -221,6 +223,8 @@ defmodule Romeo.Transports.TCP do
   end
   def recv(%Conn{socket: {:ssl, socket}, timeout: timeout} = conn, fun) do
     receive do
+      {:xmlstreamcdata, " "} ->
+        recv(conn, fun)
       {:xmlstreamelement, stanza} ->
         fun.(conn, stanza)
       {:ssl, ^socket, " "} ->


### PR DESCRIPTION
I'm using this to connect to google servers. 

I'm receiving an `{:xmlstreamcdata, <<" ">>}` whitespace when establishing the session at `tcp.ex:147` causing an unmatched clause.

This only happens on OTP 22.1. It doesn't happen on OTP 21.1 so it's hard to pinpoint which is causing it. Maybe you have an idea or a better solution?